### PR TITLE
[Feature] 기록 생성 로직 변경

### DIFF
--- a/src/main/java/bookhive/bookhiveserver/domain/post/dto/PostRequest.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/dto/PostRequest.java
@@ -1,6 +1,6 @@
 package bookhive.bookhiveserver.domain.post.dto;
 
-import bookhive.bookhiveserver.domain.tag.entity.Tag;
+import bookhive.bookhiveserver.domain.tag.dto.TagRequest;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -8,5 +8,5 @@ import lombok.Getter;
 @Getter
 public class PostRequest {
     private String content;
-    private List<Tag> tags = new ArrayList<>();
+    private List<TagRequest> tags = new ArrayList<>();
 }

--- a/src/main/java/bookhive/bookhiveserver/domain/post/service/PostService.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/service/PostService.java
@@ -47,7 +47,7 @@ public class PostService {
 
         for (TagRequest tag : tags) {
             Long tagId = tag.getId();
-            if (tagId == null) {
+            if (tagId == null) { // 태그가 존재하지 않는다면 생성하는 로직 추가
                 Tag newTag = tagRepository.save(new Tag(tag.getValue(), user));
                 fetchedTags.add(newTag);
             }

--- a/src/main/java/bookhive/bookhiveserver/domain/post/service/PostService.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/service/PostService.java
@@ -5,7 +5,6 @@ import bookhive.bookhiveserver.domain.post.entity.Post;
 import bookhive.bookhiveserver.domain.post.entity.PostTag;
 import bookhive.bookhiveserver.domain.post.repository.PostRepository;
 import bookhive.bookhiveserver.domain.tag.dto.TagRequest;
-import bookhive.bookhiveserver.domain.tag.dto.TagResponse;
 import bookhive.bookhiveserver.domain.tag.entity.Tag;
 import bookhive.bookhiveserver.domain.tag.repository.TagRepository;
 import bookhive.bookhiveserver.domain.user.entity.User;


### PR DESCRIPTION
- 기록 생성 시 존재하지 않는 태그가 있다면 생성해서 기록과 함께 저장합니다.
- 태그 생성이 따로 이루어지게 된다면, 사용자가 기록 생성 화면에서 뒤로가기를 눌렀을 때에도 태그는 생성되어 있는 부자연스러운 동작이 일어날 수 있습니다.