### PR TITLE
[Feature] 중복 생성 관련 논리 예외 처리 

### DIFF
--- a/src/main/java/bookhive/bookhiveserver/domain/clova/controller/ContentController.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/controller/ContentController.java
@@ -29,7 +29,7 @@ public class ContentController {
     public ResponseEntity<List<RecommendTagResponse>> recommend(@RequestHeader("Authorization") String token,
                                                        @RequestBody ContentRequest request) {
         String tagValues = contentService.callClovaApiToRecommend(request, token);
-        List<RecommendTagResponse> tags = contentService.createRecommendTagList(tagValues);
+        List<RecommendTagResponse> tags = contentService.createRecommendTagList(tagValues, token);
 
         return ResponseEntity.ok(tags);
     }

--- a/src/main/java/bookhive/bookhiveserver/domain/post/service/PostService.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/service/PostService.java
@@ -12,6 +12,7 @@ import bookhive.bookhiveserver.domain.user.repository.UserRepository;
 import bookhive.bookhiveserver.global.exception.ErrorMessage;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -43,6 +44,7 @@ public class PostService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, ErrorMessage.INVALID_TOKEN.toString()));
 
         List<Tag> fetchedTags = new ArrayList<>();
+        Set<Long> currentTagIds = new HashSet<>();
 
         for (TagRequest tag : tags) {
             Long tagId = tag.getId();
@@ -51,9 +53,12 @@ public class PostService {
                 fetchedTags.add(newTag);
             }
             else {
-                Tag fetchedTag = tagRepository.findById(tagId)
-                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ErrorMessage.INVALID_TAG.toString() + tagId));
-                fetchedTags.add(fetchedTag);
+                if (!currentTagIds.contains(tagId)) {
+                    Tag fetchedTag = tagRepository.findById(tagId)
+                            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ErrorMessage.INVALID_TAG.toString() + tagId));
+                    fetchedTags.add(fetchedTag);
+                    currentTagIds.add(fetchedTag.getId());
+                }
             }
         }
 

--- a/src/main/java/bookhive/bookhiveserver/domain/tag/controller/TagController.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/tag/controller/TagController.java
@@ -47,7 +47,6 @@ public class TagController {
     @DeleteMapping("/{tagId}")
     public void deleteTag(@RequestHeader("Authorization") String token,
                             @PathVariable String tagId) {
-
         tagService.deleteTag(tagId, token);
     }
 

--- a/src/main/java/bookhive/bookhiveserver/domain/tag/repository/TagRepository.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/tag/repository/TagRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findAllByUserOrderByValue(User user) ;
     List<Tag> findAllByUser(User user);
-    Tag findByValue(String value);
+    List<Tag> findByValueInAndUser(List<String> values, User user);
 }

--- a/src/main/java/bookhive/bookhiveserver/domain/tag/service/TagService.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/tag/service/TagService.java
@@ -36,6 +36,8 @@ public class TagService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, ErrorMessage.INVALID_TOKEN.toString()));
         Tag tag = new Tag(value, user);
 
+        // 태그 중복 로직 검증 (단, 해당 API는 현재 미사용이므로 보류)
+
         return tagRepository.save(tag);
     }
 

--- a/src/main/java/bookhive/bookhiveserver/domain/tag/service/TagService.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/tag/service/TagService.java
@@ -8,8 +8,11 @@ import bookhive.bookhiveserver.domain.user.entity.User;
 import bookhive.bookhiveserver.domain.user.repository.UserRepository;
 import bookhive.bookhiveserver.global.exception.ErrorMessage;
 import jakarta.transaction.Transactional;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -46,20 +49,36 @@ public class TagService {
         User user = userRepository.findByToken(token)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, ErrorMessage.INVALID_TOKEN.toString()));
 
+        // 성능 개선: 사용자의 태그를 미리 조회해두고, 해당 요청에서 생성되는 태그는 직접 추가
+        List<Tag> currentTags = tagRepository.findAllByUser(user);
+        Map<Long, Tag> tagById = currentTags.stream().collect(Collectors.toMap(Tag::getId, tag -> tag)); // 기존 태그를 위해
+        Set<String> tagValues = currentTags.stream().map(Tag::getValue).collect(Collectors.toSet()); // 새로운 태그를 위해
+
+        // 요청 내에서 중복된 value 방지
+        Set<String> newTagsInRequest = new HashSet<>();
+
         for (TagRequest tagRequest : tagRequests) {
             Long tagId = tagRequest.getId();
-            if (tagId != null) {
-                Tag tag = tagRepository.findById(tagId)
-                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ErrorMessage.INVALID_TAG.toString() + tagRequest.getId()));
+            String newValue = tagRequest.getValue();
 
-                if (!Objects.equals(tag.getValue(), tagRequest.getValue())) {
-                    tag.update(tagRequest.getValue());
+            if (tagId != null) {
+                Tag tag = tagById.get(tagId);
+                if (tag == null) {
+                    throw new ResponseStatusException(HttpStatus.NOT_FOUND, ErrorMessage.INVALID_TAG.toString() + tagRequest.getId());
+                }
+
+                if (!Objects.equals(tag.getValue(), newValue)) {
+                    tag.update(newValue);
                 }
             } else {
-                tagRepository.save(new Tag(tagRequest.getValue(), user));
+                if (!tagValues.contains(newValue) && newTagsInRequest.add(newValue)) {
+                    tagRepository.save(new Tag(newValue, user));
+                    tagValues.add(newValue);
+                }
             }
         }
     }
+
 
     public void deleteTag(String tagId, String token) {
         User user = userRepository.findByToken(token)


### PR DESCRIPTION
- 태그 편집 시, 값이 동일한 태그를 생성할 수 없도록 처리합니다.
- 기록 생성 시, id가 동일한 태그가 여러 개 들어오는 예외를 방지합니다.