### PR TITLE
[Fix] hibernate session 충돌 오류 수정

### DIFF
--- a/src/main/java/bookhive/bookhiveserver/domain/post/entity/Post.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/entity/Post.java
@@ -54,9 +54,7 @@ public class Post {
         this.user = user;
     }
 
-    public void update(String newContent, List<PostTag> updatedPostTags) {
+    public void update(String newContent) {
         this.content = newContent;
-        this.postTags.clear();
-        this.postTags.addAll(updatedPostTags);
     }
 }

--- a/src/main/java/bookhive/bookhiveserver/domain/post/repository/PostTagRepository.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/repository/PostTagRepository.java
@@ -1,0 +1,18 @@
+package bookhive.bookhiveserver.domain.post.repository;
+
+import bookhive.bookhiveserver.domain.post.entity.PostTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+
+    @Modifying
+    @Query("delete from PostTag pt where pt.post.id = :postId")
+    void deleteByPostId(@Param("postId")Long postId);
+
+    @Modifying
+    @Query(value = "INSERT INTO post_tag (post_id, tag_id) VALUES (:postId, :tagId)", nativeQuery = true)
+    void insertPostTag(@Param("postId") Long postId, @Param("tagId") Long tagId);
+}


### PR DESCRIPTION
- 복합 키를 사용하는 중간 엔티티는 JPA 1차 캐시에 의존하지 않도록 만든다.
- 꼭 영속성 컨텍스트를 활용할 필요가 없다!!