### PR TITLE
[Feature] AI 검색 기능 구현

### DIFF
--- a/src/main/java/bookhive/bookhiveserver/domain/clova/client/ClovaContentApiClient.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/client/ClovaContentApiClient.java
@@ -13,18 +13,17 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class ClovaApiClient {
+public class ClovaContentApiClient {
     private final WebClient webClient;
 
-    @Value("${clova.url}")
+    @Value("${clova.content-url}")
     private String clovaUrl;
 
     @Value("${clova.api-key}")
     private String clovaApiKey;
 
-    public String callFix(String content) {
+    public String correctErrors(String content) {
 
-        // system 프롬프트 주입
         List<ClovaMessage> messages = List.of(
                 new ClovaMessage("system",
                         "# 역할\n"
@@ -61,9 +60,8 @@ public class ClovaApiClient {
         return callApiByWebClient(request);
     }
 
-    public String callRecommend(String content, String originTags) {
+    public String recommendTags(String content, String originTags) {
 
-        // system 프롬프트 주입
         List<ClovaMessage> messages = List.of(
                 new ClovaMessage("system",
                         "당신은 OCR 기술로 인식된 책 문장 데이터를 바탕으로 어울리는 태그를 추천하는 AI입니다. 다음 제약 사항을 바탕으로 가장 적절한 태그들을 추천해 주세요.\n\n"
@@ -82,6 +80,7 @@ public class ClovaApiClient {
 
         return callApiByWebClient(request);
     }
+
 
     private String callApiByWebClient(ClovaRequest request) {
         return webClient.post()

--- a/src/main/java/bookhive/bookhiveserver/domain/clova/client/ClovaSearchApiClient.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/client/ClovaSearchApiClient.java
@@ -1,0 +1,163 @@
+package bookhive.bookhiveserver.domain.clova.client;
+
+import bookhive.bookhiveserver.domain.clova.dto.request.ClovaMessage;
+import bookhive.bookhiveserver.domain.clova.dto.request.ClovaRequest;
+import bookhive.bookhiveserver.domain.clova.dto.response.ClovaResponse;
+import bookhive.bookhiveserver.domain.clova.dto.response.KeywordsResponse;
+import bookhive.bookhiveserver.domain.clova.dto.response.SearchTypeResponse;
+import bookhive.bookhiveserver.global.exception.ErrorMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ClovaSearchApiClient {
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${clova.search-url}")
+    private String clovaUrl;
+
+    @Value("${clova.api-key}")
+    private String clovaApiKey;
+
+    public SearchTypeResponse checkSearchType(String question) {
+
+        List<ClovaMessage> messages = List.of(
+                new ClovaMessage("system",
+                        """
+                                - 사용자의 질문을 분석하여, 검색어가 명확한지 판단해주세요.
+
+                                # 예시
+
+                                가을이 들어간 구절을 검색해줘.
+                                { "isSearch": "true", "keyword": "가을" }
+                                ###
+                                마케팅이란 문구가 들어간 기록을 보고싶어.
+                                { "isSearch": "true", "keyword": "마케팅" }
+                                ###
+                                마케팅에 도움이 되는 기록을 보여줘.
+                                { "isSearch": "false", "keyword": null }
+                                ###
+                                공부라는 키워드가 들어간 아카이브를 보여줘.
+                                { "isSearch": "true", "keyword": "공부" }
+                                ###
+                                공부에 집중할 수 있도록 마음을 다잡는 데 도움을 주는 구절을 보여줘.
+                                { "isSearch": "false", "keyword": null }
+                                ###
+                                인간관계에서 도움을 얻을 수 있는 구절이 있어?
+                                { "isSearch": "false", "keyword": null }
+                                ###
+                                자꾸 불안함이 들 때 위로가 되는 문구를 보고 싶어.
+                                { "isSearch": "false", "keyword": null }
+                                ###
+                                운동
+                                { "isSearch": "true", "keyword": "운동" }
+                                ###
+                                배고파
+                                { "isSearch": "false", "keyword": null }
+                                ###
+                                기분이 좋지 않아.
+                                { "isSearch": "false", "keyword": null }
+
+                                - 다음 질문을 보고 같은 형식으로 JSON을 반환하세요."""),
+                new ClovaMessage("user", question)
+        );
+
+        ClovaRequest request = new ClovaRequest(messages);
+
+        String jsonString = webClient.post()
+                            .uri(clovaUrl)
+                            .header("Authorization", clovaApiKey)
+                            .header("Content-Type", "application/json")
+                            .bodyValue(request)
+                            .retrieve()
+                            .bodyToMono(ClovaResponse.class)
+                            .map(clovaResponse -> clovaResponse.getResult().getMessage().getContent())
+                            .block();
+
+        System.out.println("키워드 검색 결과: \n" + jsonString);
+
+        try {
+            return objectMapper.readValue(jsonString, SearchTypeResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ErrorMessage.JSON_PARSE_ERROR.toString(), e);
+        }
+}
+
+    public KeywordsResponse extractKeywords(String question, String originTags) {
+
+        List<ClovaMessage> messages = List.of(
+                new ClovaMessage("system",
+                        """
+                                - 사용자의 태그 리스트에서 질문과 관련 있는 키워드를 추출하세요.
+                                - 질문과 관련된 새로운 키워드도 추출하세요.
+                                - 키워드는 최대 8개까지 추출하세요.
+                                - 답변 형식은 JSON 형식으로 답변해주세요.
+
+                                # 예시
+
+                                질문: 인간관계에 도움이 되는 구절이 있을까?
+                                태그 리스트: ["철학", "심리", "사랑", "우정"]
+
+                                { "keywords": ["심리", "사랑", "우정", "인간관계", "소통", "대화", "친구", "감정"] }
+                                ###
+                                질문: 취미활동에 도움이 되는 아카이브를 보여줘.
+                                태그 리스트: ["개발", "공부", "일상", "스포츠", "여행", "마케팅"]
+
+                                { "keywords": ["일상", "스포츠", "여행", "취미", "즐거움"] }
+                                ###
+                                질문: 자꾸 불안함이 들 때 위로가 되는 문구를 보고 싶어.
+                                태그 리스트: ["마케팅", "세일즈", "우정", "마음가짐", "사랑", "공부"]
+
+                                { "keywords": ["우정", "마음가짐", "사랑", "위로", "감정", "불안"] }
+                                ###
+                                질문: 지식 쌓기에 도움이 되는 문장들을 보여줘.
+                                태그 리스트: ["개발", "공부", "디자인", "건강", "요리", "마음가짐"]
+
+                                { "keywords": ["개발", "공부", "학습", "배움", "지식"] }
+                                ###
+                                질문: 중요한 시험을 앞뒀을 때 도움이 되는 구절을 추천해줘.
+                                태그 리스트: ["인문학", "요리", "연인", "건강", "스포츠", "마음가짐"]
+
+                                { "keywords": ["마음가짐", "긴장", "휴식", "자신감", "시험"] }
+
+                                - 다음 질문과 사용자가 가진 태그 리스트를 보고, 관련된 키워드를 추출하세요.
+                                """
+                ),
+                new ClovaMessage("user",
+                        "질문: " + question + "\n"
+                                + "태그 리스트: [" + originTags + "]\n"
+                )
+        );
+
+        ClovaRequest request = new ClovaRequest(messages);
+
+        String jsonString =  webClient.post()
+                            .uri(clovaUrl)
+                            .header("Authorization", clovaApiKey)
+                            .header("Content-Type", "application/json")
+                            .bodyValue(request)
+                            .retrieve()
+                            .bodyToMono(ClovaResponse.class)
+                            .map(clovaResponse -> clovaResponse.getResult().getMessage().getContent())
+                            .block();
+
+        System.out.println("AI 검색 결과: \n" + jsonString);
+
+        try {
+            return objectMapper.readValue(jsonString, KeywordsResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ErrorMessage.JSON_PARSE_ERROR.toString(), e);
+        }
+    }
+}

--- a/src/main/java/bookhive/bookhiveserver/domain/clova/controller/SearchController.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/controller/SearchController.java
@@ -1,10 +1,12 @@
 package bookhive.bookhiveserver.domain.clova.controller;
 
-import bookhive.bookhiveserver.domain.clova.dto.request.ContentRequest;
+import bookhive.bookhiveserver.domain.clova.dto.request.SearchRequest;
+import bookhive.bookhiveserver.domain.clova.dto.response.SearchTypeResponse;
 import bookhive.bookhiveserver.domain.clova.service.SearchService;
 import bookhive.bookhiveserver.domain.post.dto.PostResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -21,10 +24,33 @@ public class SearchController {
 
     @PostMapping("/ai-search-posts")
     public ResponseEntity<List<PostResponse>> search(@RequestHeader(value = "Authorization") String token,
-                                                     @RequestBody ContentRequest request) {
+                                           @RequestBody SearchRequest request) {
 
-        List<PostResponse> posts = searchService.getRandomPosts(token);
+        try {
+            log.info( "키워드 검색 시작");
+            SearchTypeResponse searchType = searchService.checkSearchType(request);
+            List<PostResponse> posts;
 
-        return ResponseEntity.ok(posts);
+            System.out.println(searchType.getIsSearch());
+            System.out.println(searchType.getKeyword());
+
+            if (Boolean.parseBoolean(searchType.getIsSearch())) {
+                log.info( "키워드 검색");
+                posts = searchService.searchByKeyword(searchType.getKeyword(), token);
+            } else {
+                log.info( "AI 검색");
+                posts = searchService.searchByAI(request, token);
+            }
+
+            if (posts.isEmpty()) {
+                log.info("맞는 결과 없음");
+                posts = searchService.getRandomPosts(token);
+            }
+
+            return ResponseEntity.ok(posts);
+        } catch (Exception e) {
+            List<PostResponse> randomPosts = searchService.getRandomPosts(token);
+            return ResponseEntity.ok(randomPosts);
+        }
     }
 }

--- a/src/main/java/bookhive/bookhiveserver/domain/clova/dto/request/SearchRequest.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/dto/request/SearchRequest.java
@@ -1,0 +1,14 @@
+package bookhive.bookhiveserver.domain.clova.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchRequest {
+    private String question;
+}

--- a/src/main/java/bookhive/bookhiveserver/domain/clova/dto/response/KeywordsResponse.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/dto/response/KeywordsResponse.java
@@ -1,0 +1,11 @@
+package bookhive.bookhiveserver.domain.clova.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KeywordsResponse {
+    private List<String> keywords;
+}

--- a/src/main/java/bookhive/bookhiveserver/domain/clova/dto/response/SearchTypeResponse.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/dto/response/SearchTypeResponse.java
@@ -1,0 +1,11 @@
+package bookhive.bookhiveserver.domain.clova.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SearchTypeResponse {
+    private String isSearch;
+    private String keyword;
+}

--- a/src/main/java/bookhive/bookhiveserver/domain/clova/service/ContentService.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/clova/service/ContentService.java
@@ -1,6 +1,6 @@
 package bookhive.bookhiveserver.domain.clova.service;
 
-import bookhive.bookhiveserver.domain.clova.client.ClovaApiClient;
+import bookhive.bookhiveserver.domain.clova.client.ClovaContentApiClient;
 import bookhive.bookhiveserver.domain.clova.dto.request.ContentRequest;
 import bookhive.bookhiveserver.domain.clova.dto.response.RecommendTagResponse;
 import bookhive.bookhiveserver.domain.tag.entity.Tag;
@@ -22,12 +22,12 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 @RequiredArgsConstructor
 public class ContentService {
-    private final ClovaApiClient clovaApiClient;
+    private final ClovaContentApiClient clovaContentApiClient;
     private final UserRepository userRepository;
     private final TagRepository tagRepository;
 
     public String callClovaApiToFix(ContentRequest request) {
-        return clovaApiClient.callFix(request.getContent());
+        return clovaContentApiClient.correctErrors(request.getContent());
     }
 
     public String callClovaApiToRecommend(ContentRequest request, String token) {
@@ -39,7 +39,7 @@ public class ContentService {
 
         String originTags = String.join(", ", tagNames);
 
-        return clovaApiClient.callRecommend(request.getContent(), originTags);
+        return clovaContentApiClient.recommendTags(request.getContent(), originTags);
     }
 
     public List<RecommendTagResponse> createRecommendTagList(String tagValues, String token) {

--- a/src/main/java/bookhive/bookhiveserver/domain/post/repository/PostRepository.java
+++ b/src/main/java/bookhive/bookhiveserver/domain/post/repository/PostRepository.java
@@ -4,10 +4,14 @@ import bookhive.bookhiveserver.domain.post.entity.Post;
 import bookhive.bookhiveserver.domain.user.entity.User;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByUser(User user);
     List<Post> findByUserOrderByCreatedAtDesc(User user);
+
+    @Query("select p from Post p where p.user = :user and p.content like %:keyword%")
+    List<Post> findByUserAndKeyword(User user, String keyword);
 }

--- a/src/main/java/bookhive/bookhiveserver/global/exception/ErrorMessage.java
+++ b/src/main/java/bookhive/bookhiveserver/global/exception/ErrorMessage.java
@@ -2,10 +2,10 @@ package bookhive.bookhiveserver.global.exception;
 
 public enum ErrorMessage {
     TOO_MANY_LETTERS("[ERROR] 글자수를 초과하였습니다."),
+    JSON_PARSE_ERROR("[ERROR] JSON을 파싱할 수 없습니다"),
     INVALID_TOKEN("[ERROR] 잘못된 토큰입니다. "),
     INVALID_POST("[ERROR] 존재하지 않는 게시글입니다. "),
     INVALID_TAG("[ERROR] 존재하지 않는 태그입니다. "),
-    INVALID_API_RESPONSE("[ERROR] 현재 CLOVA API가 올바른 응답을 제공할 수 없습니다."),
     UNAUTHORIZED_POST("[ERROR] 해당 게시글에 접근 권한이 없습니다. "),
     UNAUTHORIZED_TAG("[ERROR] 해당 태그에 접근 권한이 없습니다. ");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       ddl-auto: validate
 
 clova:
-  url: ${CLOVA_URL}
+  search-url: ${CLOVA_SEARCH_URL}
+  content-url: ${CLOVA_CONTENT_URL}
   api-key: ${CLOVA_API_KEY}
   request-id: ${CLOVA_REQUEST_ID}


### PR DESCRIPTION
**1. [검색 형태 체크 LLM]에게 첫 번째 API 요청을 보냅니다.**
- 검색어가 명확하면, 서버 자체에서 해당 검색어를 본문에 가지고 있는 기록들을 필터링해 반환합니다.

**2. 검색어가 명확하지 않을 시 [키워드 추출 LLM]에게 두 번째 API 요청을 보냅니다.**
- 해당 LLM은 사용자의 태그 리스트와 검색창에 입력된 질문을 보고 관련된 키워드들을 추출합니다.
- 서버는 응답 결과인 키워드들을 기준으로, 키워드가 포함된 태그를 가졌거나 키워드가 본문에 포함된 기록들을 필터링해 반환합니다.

**3. 질문에 어울리는 기록이 없거나 예기치 못한 에러가 발생하면, 사용자의 기록들 중 랜덤으로 3개를 반환합니다.**
- 게시글이 3개가 되지 않더라도 에러가 발생하지 않고, 3개 이하의 게시글을 반환합니다.